### PR TITLE
[WIP]New clients inboxes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ go:
 - 1.11.x
 go_import_path: github.com/nats-io/gnatsd
 install:
-- go get -u github.com/bfoxstudio/go-nats
 - go get github.com/nats-io/nkeys
 - go get github.com/nats-io/jwt
 - go get github.com/mattn/goveralls
@@ -12,10 +11,11 @@ install:
 - go get -u honnef.co/go/tools/cmd/staticcheck
 - go get -u github.com/client9/misspell/cmd/misspell
 before_script:
+- go get -u github.com/bfoxstudio/go-nats
 - mv $GOPATH/src/github.com/bfoxstudio/go-nats $GOPATH/src/github.com/nats-io/go-nats
 - ls -a
 - pwd
-- ls $GOPATH/src/github.com/nats-io/go-nats
+- ls $GOPATH/src/github.com/nats-io/go-nats/.github
 - git status $GOPATH/src/github.com/nats-io/go-nats
 - git rev-parse HEAD
 - EXCLUDE_VENDOR=$(go list ./... | grep -v "/vendor/")

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
 - 1.11.x
 go_import_path: github.com/nats-io/gnatsd
 install:
+- go get github.com/nats-io/nuid
 - go get github.com/nats-io/nkeys
 - go get github.com/nats-io/jwt
 - go get github.com/mattn/goveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ install:
 - go get -u github.com/client9/misspell/cmd/misspell
 before_script:
 - mv $GOPATH/src/github.com/bfoxstudio/go-nats $GOPATH/src/github.com/nats-io/go-nats
+- ls -a
+- pwd
+- ls $GOPATH/src/github.com/nats-io/go-nats
+- git status ./$GOPATH/src/github.com/nats-io/go-nats
+- git rev-parse HEAD
 - EXCLUDE_VENDOR=$(go list ./... | grep -v "/vendor/")
 - go build
 - $(exit $(go fmt $EXCLUDE_VENDOR | wc -l))

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
 - 1.11.x
 go_import_path: github.com/nats-io/gnatsd
 install:
-- go get github.com/nats-io/go-nats
+- go get github.com/bfoxstudio/go-nats
 - go get github.com/nats-io/nkeys
 - go get github.com/nats-io/jwt
 - go get github.com/mattn/goveralls
@@ -12,6 +12,7 @@ install:
 - go get -u honnef.co/go/tools/cmd/staticcheck
 - go get -u github.com/client9/misspell/cmd/misspell
 before_script:
+- mv $GOPATH/src/github.com/bfoxstudio/go-nats $GOPATH/src/github.com/nats-io/go-nats
 - EXCLUDE_VENDOR=$(go list ./... | grep -v "/vendor/")
 - go build
 - $(exit $(go fmt $EXCLUDE_VENDOR | wc -l))

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
 - 1.11.x
 go_import_path: github.com/nats-io/gnatsd
 install:
-- go get github.com/bfoxstudio/go-nats
+- go get -u github.com/bfoxstudio/go-nats
 - go get github.com/nats-io/nkeys
 - go get github.com/nats-io/jwt
 - go get github.com/mattn/goveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,7 @@ install:
 - go get -u honnef.co/go/tools/cmd/staticcheck
 - go get -u github.com/client9/misspell/cmd/misspell
 before_script:
-- go get -u github.com/bfoxstudio/go-nats
-- mv $GOPATH/src/github.com/bfoxstudio/go-nats $GOPATH/src/github.com/nats-io/go-nats
-- ls -a
-- pwd
-- ls $GOPATH/src/github.com/nats-io/go-nats/.github
-- git status $GOPATH/src/github.com/nats-io/go-nats
-- git rev-parse HEAD
+- git clone --depth=50 --branch=new_inbox https://github.com/bfoxstudio/go-nats.git $GOPATH/src/github.com/nats-io/go-nats
 - EXCLUDE_VENDOR=$(go list ./... | grep -v "/vendor/")
 - go build
 - $(exit $(go fmt $EXCLUDE_VENDOR | wc -l))

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
 - ls -a
 - pwd
 - ls $GOPATH/src/github.com/nats-io/go-nats
-- git status ./$GOPATH/src/github.com/nats-io/go-nats
+- git status $GOPATH/src/github.com/nats-io/go-nats
 - git rev-parse HEAD
 - EXCLUDE_VENDOR=$(go list ./... | grep -v "/vendor/")
 - go build

--- a/README.md
+++ b/README.md
@@ -575,6 +575,8 @@ Before server `1.3.0`, it was only possible to define permissions allowing an au
 
 Each permission grant is an object with two fields: what subject(s) the authenticated user is allowed (or denied the right) to publish to, and what subject(s) the authenticated user is allowed (or denied the right) to subscribe to. The parser is generous at understanding what the intent is, so both arrays and singletons are processed. Subjects themselves can contain wildcards. Permissions make use of [variables](#variables).
 
+In new version use clients section for automatically allow subscribe and publish to  "_INBOX._CLIENTS.ClientIdXYZ.>". Not use "_INBOX.>" publish and subscribe with clients. "_INBOX.>" will be allowed to write and read other _INBOX._CLIENTS. 
+
 You set permissions by creating an entry inside of the `authorization` configuration block that conforms to the following syntax:
 ```
 authorization {
@@ -586,6 +588,9 @@ authorization {
     subscribe = {
       allow = "singleton" or ["array", ...]
       deny  = "singleton" or ["array", ...]
+    }
+    clients = {
+      allow: ["test1", "test2"]
     }
   }
 }
@@ -600,6 +605,8 @@ authorization {
   }
 }
 ```
+
+
 
 Here is an example authorization configuration that defines four users, three of whom are assigned explicit permissions.
 ```
@@ -619,6 +626,9 @@ authorization {
   DEFAULT_PERMISSIONS = {
     publish = "SANDBOX.*"
     subscribe = ["PUBLIC.>", "_INBOX.>"]
+    clients = {
+          allow: ["test1", "test2"]
+    }
   }
 
   PASS: abcdefghijklmnopqrstuvwxwz0123456789

--- a/server/auth.go
+++ b/server/auth.go
@@ -93,6 +93,13 @@ type SubjectPermission struct {
 type Permissions struct {
 	Publish   *SubjectPermission `json:"publish"`
 	Subscribe *SubjectPermission `json:"subscribe"`
+	Clients   *ClientsPermission `json:"clients"`
+}
+
+// SubjectPermission is an individual allow and deny struct for publish
+// and subscribe authorizations.
+type ClientsPermission struct {
+	AllowedClientIds []string `json:"allowed_client_ids,omitempty"`
 }
 
 // RoutePermissions are similar to user permissions
@@ -120,6 +127,19 @@ func (p *SubjectPermission) clone() *SubjectPermission {
 	return clone
 }
 
+// clone will clone an individual client permission.
+func (p *ClientsPermission) clone() *ClientsPermission {
+	if p == nil {
+		return nil
+	}
+	clone := &ClientsPermission{}
+	if p.AllowedClientIds != nil {
+		clone.AllowedClientIds = make([]string, len(p.AllowedClientIds))
+		copy(clone.AllowedClientIds, p.AllowedClientIds)
+	}
+	return clone
+}
+
 // clone performs a deep copy of the Permissions struct, returning a new clone
 // with all values copied.
 func (p *Permissions) clone() *Permissions {
@@ -132,6 +152,9 @@ func (p *Permissions) clone() *Permissions {
 	}
 	if p.Subscribe != nil {
 		clone.Subscribe = p.Subscribe.clone()
+	}
+	if p.Clients != nil {
+		clone.Clients = p.Clients.clone()
 	}
 	return clone
 }

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -42,6 +42,9 @@ func TestUserClone(t *testing.T) {
 		Username: "foo",
 		Password: "bar",
 		Permissions: &Permissions{
+			Clients: &ClientsPermission{
+				AllowedClientIds: []string{"tmp"},
+			},
 			Publish: &SubjectPermission{
 				Allow: []string{"foo"},
 			},

--- a/server/configs/reload/authorization_1.conf
+++ b/server/configs/reload/authorization_1.conf
@@ -24,6 +24,9 @@ authorization {
       allow: ["PUBLIC.>", "foo.*"]
       deny: "foo.bar"
     }
+    clients = {
+        allow: ["test1", "test2"]
+    }
   }
 
   # Default permissions if none presented. e.g. susan below.

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -1546,6 +1546,8 @@ func (c *client) processGatewayRUnsub(arg []byte) error {
 	ei, _ := c.gw.outsim.Load(accName)
 	if ei != nil {
 		e = ei.(*outsie)
+		e.Lock()
+		defer e.Unlock()
 		// If there is an entry, for plain sub we need
 		// to know if we should store the sub
 		useSl = queue != nil || e.mode != modeOptimistic
@@ -1558,8 +1560,6 @@ func (c *client) processGatewayRUnsub(arg []byte) error {
 		e = &outsie{ni: make(map[string]struct{}), sl: NewSublist()}
 		newe = true
 	}
-	e.Lock()
-	defer e.Unlock()
 	// This is when a sub or queue sub is supposed to be in
 	// the sublist. Look for it and remove.
 	if useSl {
@@ -1634,6 +1634,8 @@ func (c *client) processGatewayRSub(arg []byte) error {
 	// getting many RS- from the remote..
 	if ei != nil {
 		e = ei.(*outsie)
+		e.Lock()
+		defer e.Unlock()
 		useSl = queue != nil || e.mode != modeOptimistic
 	} else if queue == nil {
 		return nil
@@ -1642,8 +1644,6 @@ func (c *client) processGatewayRSub(arg []byte) error {
 		newe = true
 		useSl = true
 	}
-	e.Lock()
-	defer e.Unlock()
 	if useSl {
 		var key []byte
 		// We store remote subs by account/subject[/queue].

--- a/server/gateway.go
+++ b/server/gateway.go
@@ -157,6 +157,8 @@ type outsie struct {
 	// Contains queue subscriptions when in optimistic mode,
 	// and all subs when pk is > 0.
 	sl *Sublist
+	// Number of queue subs
+	qsubs int
 }
 
 // Inbound subject interest entry.
@@ -896,14 +898,8 @@ func (c *client) processGatewayInfo(info *Info) {
 		// Now that it is registered, we can remove from temp map.
 		s.removeFromTempClients(cid)
 
-		// Send our QSubs, since this may take some time, execute
-		// in a separate go-routine so that if there is incoming
-		// data from the otherside, we don't cause a slow consumer
-		// error.
-		s.startGoRoutine(func() {
-			s.sendQueueSubsToGateway(c)
-			s.grWG.Done()
-		})
+		// Send our QSubs.
+		s.sendQueueSubsToGateway(c)
 
 		// Initiate outbound connection. This function will behave correctly if
 		// we have already one.
@@ -1112,7 +1108,7 @@ func (s *Server) sendGatewayConfigsToRoute(route *client) {
 		return
 	}
 	// Collect gateway configs for which we have an outbound connection.
-	gwCfgsa := [4]*gatewayCfg{}
+	gwCfgsa := [16]*gatewayCfg{}
 	gwCfgs := gwCfgsa[:0]
 	for _, c := range gw.out {
 		c.mu.Lock()
@@ -1550,8 +1546,6 @@ func (c *client) processGatewayRUnsub(arg []byte) error {
 	ei, _ := c.gw.outsim.Load(accName)
 	if ei != nil {
 		e = ei.(*outsie)
-		e.Lock()
-		defer e.Unlock()
 		// If there is an entry, for plain sub we need
 		// to know if we should store the sub
 		useSl = queue != nil || e.mode != modeOptimistic
@@ -1564,6 +1558,8 @@ func (c *client) processGatewayRUnsub(arg []byte) error {
 		e = &outsie{ni: make(map[string]struct{}), sl: NewSublist()}
 		newe = true
 	}
+	e.Lock()
+	defer e.Unlock()
 	// This is when a sub or queue sub is supposed to be in
 	// the sublist. Look for it and remove.
 	if useSl {
@@ -1577,6 +1573,7 @@ func (c *client) processGatewayRUnsub(arg []byte) error {
 		if e.sl.Remove(sub) == nil {
 			delete(c.subs, string(key))
 			if queue != nil {
+				e.qsubs--
 				atomic.AddInt64(&c.srv.gateway.totalQSubs, -1)
 			}
 			// If last, we can remove the whole entry only
@@ -1637,8 +1634,6 @@ func (c *client) processGatewayRSub(arg []byte) error {
 	// getting many RS- from the remote..
 	if ei != nil {
 		e = ei.(*outsie)
-		e.Lock()
-		defer e.Unlock()
 		useSl = queue != nil || e.mode != modeOptimistic
 	} else if queue == nil {
 		return nil
@@ -1647,6 +1642,8 @@ func (c *client) processGatewayRSub(arg []byte) error {
 		newe = true
 		useSl = true
 	}
+	e.Lock()
+	defer e.Unlock()
 	if useSl {
 		var key []byte
 		// We store remote subs by account/subject[/queue].
@@ -1680,11 +1677,12 @@ func (c *client) processGatewayRSub(arg []byte) error {
 		// If no error inserting in sublist...
 		if e.sl.Insert(sub) == nil {
 			c.subs[string(key)] = sub
+			if queue != nil {
+				e.qsubs++
+				atomic.AddInt64(&c.srv.gateway.totalQSubs, 1)
+			}
 			if newe {
 				c.gw.outsim.Store(string(accName), e)
-			}
-			if queue != nil {
-				atomic.AddInt64(&c.srv.gateway.totalQSubs, 1)
 			}
 		}
 	} else {
@@ -1725,26 +1723,24 @@ func (c *client) gatewayInterest(acc, subj string) (bool, *SublistResult) {
 	if accountInMap {
 		// If in map, check for subs interest with sublist.
 		e := ei.(*outsie)
-		r = e.sl.Match(subj)
-		// If there is plain subs returned, we don't have to
-		// check if we should use the no-interest map because
-		// it means that we are in modeInterestOnly.
-		// Only if there is nothing returned for r.psubs that
-		// we need to check.
-		if len(r.psubs) > 0 {
-			psi = true
-		} else {
-			e.RLock()
-			// We may be in transition to modeInterestOnly
-			// but until e.ni is nil, use it to know if we
-			// should suppress interest or not.
-			if e.ni != nil {
-				if _, inMap := e.ni[subj]; !inMap {
-					psi = true
-				}
+		e.RLock()
+		// We may be in transition to modeInterestOnly
+		// but until e.ni is nil, use it to know if we
+		// should suppress interest or not.
+		if e.ni != nil {
+			if _, inMap := e.ni[subj]; !inMap {
+				psi = true
 			}
-			e.RUnlock()
 		}
+		// If we are in modeInterestOnly (e.ni will be nil)
+		// or if we have queue subs, we also need to check sl.Match.
+		if e.ni == nil || e.qsubs > 0 {
+			r = e.sl.Match(subj)
+			if len(r.psubs) > 0 {
+				psi = true
+			}
+		}
+		e.RUnlock()
 	}
 	return psi, r
 }
@@ -1757,7 +1753,7 @@ func (s *Server) maybeSendSubOrUnsubToGateways(accName string, sub *subscription
 	if sub.queue != nil {
 		return
 	}
-	gwsa := [4]*client{}
+	gwsa := [16]*client{}
 	gws := gwsa[:0]
 	s.getInboundGatewayConnections(&gws)
 	if len(gws) == 0 {
@@ -1856,7 +1852,7 @@ func (s *Server) sendQueueSubOrUnsubToGateways(accName string, qsub *subscriptio
 		return
 	}
 
-	gwsa := [4]*client{}
+	gwsa := [16]*client{}
 	gws := gwsa[:0]
 	s.getInboundGatewayConnections(&gws)
 	if len(gws) == 0 {
@@ -1966,7 +1962,7 @@ func (s *Server) gatewayUpdateSubInterest(accName string, sub *subscription, cha
 // subject, etc..
 // <Invoked from any client connection's readLoop>
 func (c *client) sendMsgToGateways(acc *Account, msg, subject, reply []byte, qgroups [][]byte) {
-	gwsa := [4]*client{}
+	gwsa := [16]*client{}
 	gws := gwsa[:0]
 	// This is in fast path, so avoid calling function when possible.
 	// Get the outbound connections in place instead of calling

--- a/server/monitor_test.go
+++ b/server/monitor_test.go
@@ -1651,7 +1651,7 @@ func createClientConnSubscribeAndPublish(t *testing.T, s *Server) *nats.Conn {
 	}
 
 	ch := make(chan bool)
-	inbox := nats.NewInbox()
+	inbox := nats.NewInboxWithPath("_TMP")
 	sub, err := nc.Subscribe(inbox, func(m *nats.Msg) { ch <- true })
 	if err != nil {
 		t.Fatalf("Error subscribing to `%s`: %v\n", inbox, err)

--- a/server/opts.go
+++ b/server/opts.go
@@ -1778,8 +1778,6 @@ func parseClients(v interface{}, errors, warnings *[]error) (*ClientsPermission,
 	return p, nil
 }
 
-
-
 // Helper function to parse old style authorization configs.
 func parseOldPermissionStyle(v interface{}, errors, warnings *[]error) (*SubjectPermission, error) {
 	subjects, err := parseSubjects(v, errors, warnings)

--- a/server/opts.go
+++ b/server/opts.go
@@ -1683,6 +1683,13 @@ func parseUserPermissions(mv interface{}, errors, warnings *[]error) (*Permissio
 				continue
 			}
 			p.Subscribe = perms
+		case "clients":
+			perms, err := parseClientsPermissions(v, errors, warnings)
+			if err != nil {
+				*errors = append(*errors, err)
+				continue
+			}
+			p.Clients = perms
 		default:
 			if !tk.IsUsedVariable() {
 				err := &configErr{tk, fmt.Sprintf("Unknown field %q parsing permissions", k)}
@@ -1733,6 +1740,45 @@ func parseSubjects(v interface{}, errors, warnings *[]error) ([]string, error) {
 	}
 	return subjects, nil
 }
+
+// Top level parser for authorization configurations.
+func parseClientsPermissions(v interface{}, errors, warnings *[]error) (*ClientsPermission, error) {
+	switch vv := v.(type) {
+	case map[string]interface{}:
+		// New style with allow and/or deny properties.
+		return parseClients(vv, errors, warnings)
+	}
+	return &ClientsPermission{}, nil
+}
+
+// Helper function to parse new style authorization into a SubjectPermission with Allow and Deny.
+func parseClients(v interface{}, errors, warnings *[]error) (*ClientsPermission, error) {
+	m := v.(map[string]interface{})
+	if len(m) == 0 {
+		return nil, nil
+	}
+	p := &ClientsPermission{}
+	for k, v := range m {
+		tk, _ := unwrapValue(v)
+		switch strings.ToLower(k) {
+		case "allow":
+			subjects, err := parseSubjects(tk, errors, warnings)
+			if err != nil {
+				*errors = append(*errors, err)
+				continue
+			}
+			p.AllowedClientIds = subjects
+		default:
+			if !tk.IsUsedVariable() {
+				err := &configErr{tk, fmt.Sprintf("Unknown field name %q parsing subject permissions, only 'allow' or 'deny' are permitted", k)}
+				*errors = append(*errors, err)
+			}
+		}
+	}
+	return p, nil
+}
+
+
 
 // Helper function to parse old style authorization configs.
 func parseOldPermissionStyle(v interface{}, errors, warnings *[]error) (*SubjectPermission, error) {

--- a/test/fanout_test.go
+++ b/test/fanout_test.go
@@ -45,7 +45,7 @@ func TestNoRaceHighFanoutOrdering(t *testing.T) {
 	)
 
 	// make unique
-	subj := nats.NewInbox()
+	subj := nats.NewInboxWithPath("_TMP")
 
 	var wg sync.WaitGroup
 	wg.Add(nconns * nsubs)


### PR DESCRIPTION
New clients inboxes. Necessary changes to integrate access control in NATS streaming
In new version use clients section in config for automatically allow subscribe and publish to "_INBOX._CLIENTS.ClientIdXYZ.>". Not use "_INBOX.>" publish and subscribe with clients. "_INBOX.>" will be allowed to write and read other _INBOX._CLIENTS.

go-nats client pull request https://github.com/nats-io/go-nats/pull/441
Build in travis https://travis-ci.org/bfoxstudio/gnatsd